### PR TITLE
isObjectMessage() has incorrect usage of isAssignableFrom?

### DIFF
--- a/src/main/java/com/melowe/jms2/compat/Jms2MessageUtil.java
+++ b/src/main/java/com/melowe/jms2/compat/Jms2MessageUtil.java
@@ -51,7 +51,7 @@ public final class Jms2MessageUtil {
     }
 
     static boolean isObjectMessage(Message message, Class type) {
-        return ObjectMessage.class.isInstance(message) && type.isAssignableFrom(java.io.Serializable.class);
+        return ObjectMessage.class.isInstance(message) && java.io.Serializable.class.isAssignableFrom(type);
     }
 
     static boolean isMapMessage(Message message, Class type) {


### PR DESCRIPTION
Shouldn't it be java.io.Serializable.class.isAssignableFrom(type)?

In my application, `java.io.Serializable.class.isAssignableFrom(type)` returns `true` (correctly), but `type.isAssignableFrom(Serializable)` returns `false`, so it's not considered an `ObjectMessage` even though JBoss/Wildfly says it is.
